### PR TITLE
Create MMFCollisionManager

### DIFF
--- a/MMFCollisionManager
+++ b/MMFCollisionManager
@@ -1,0 +1,43 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using MoreMountains.Feedbacks;
+using static MMFCollisionManager;
+
+public class MMFCollisionManager : MonoBehaviour
+{
+    [System.Serializable]
+    public struct MMFObjects
+    {
+        public string Name;
+        public GameObject GameObject;
+        public MMFeedbacks Feedback;
+        public LayerMask LayerMask;
+    }
+    
+    [System.Serializable]
+    public class MMFCollisionLists
+    {
+        public string Name;
+        public List<MMFObjects> feedbackObjects;
+    }
+    
+    public List<MMFCollisionLists> mMFCollisionLists;
+
+    public void CheckAndPlay(GameObject collidingObject)
+    {
+        foreach (MMFCollisionLists mMFCollisionList in mMFCollisionLists)
+        {
+            // Find the FeedbackObjects that contains the collided gameObject
+            MMFObjects feedbackObjects = mMFCollisionList.feedbackObjects.Find(x => x.GameObject == collidingObject);
+
+            // Check if the colliding object is in the specified layer
+            if (feedbackObjects.LayerMask == (feedbackObjects.LayerMask | (1 << collidingObject.gameObject.layer)))
+            {
+                // Initialize and play the feedback for the gameObject
+                feedbackObjects.Feedback.Initialization();
+                feedbackObjects.Feedback.PlayFeedbacks();
+            }
+        }
+    }
+}


### PR DESCRIPTION
There are several advantages to using the MMFCollisionManager and MMFCollisionHelper scripts in a Unity project:

Centralized management: The MMFCollisionManager script serves as a central location for managing all of the collision-based feedback effects in the project. This can make it easier to organize and manage these effects, especially if there are many of them.

Reusability: The MMFCollisionHelper script can be attached to any game object in the project, allowing you to reuse the same collision-based feedback effects on multiple objects.

Customization: The MMFCollisionManager script allows you to specify different feedback effects and layers for each game object, giving you the flexibility to customize the behavior of the collision-based feedback effects.

Modularity: The MMFCollisionManager and MMFCollisionHelper scripts are modular, meaning that they can be easily added or removed from a project without affecting the rest of the code. This can make it easier to add or remove collision-based feedback effects as needed.

Overall, using the MMFCollisionManager and MMFCollisionHelper scripts can help you to efficiently and effectively manage and trigger collision-based feedback effects in your Unity project.

Here is a step-by-step guide on how to use the MMFCollisionManager and MMFCollisionHelper scripts in a Unity project:

1) Add the MMFCollisionManager script to an empty game object in your Unity project. This will be the object that manages the collision-based feedback effects.

2) In the MMFCollisionManager script's mMFCollisionLists list, create a new MMFCollisionLists element. Set the Name field to a descriptive string.

3) In the feedbackObjects list of the new MMFCollisionLists element, create a new MMFObjects element. Set the Name field to a descriptive string.

4) Drag a game object from your scene into the GameObject field of the MMFObjects element. This will be the object that the feedback effect is triggered on when it collides with another object.

5) Drag an MMFeedbacks component from the project hierarchy into the Feedback field of the MMFObjects element. This component will handle playing the feedback effect.

6) Set the LayerMask field of the MMFObjects element to the layer or layers that the colliding object must be in for the feedback effect to be triggered.

7) Repeat steps 3-6 for each game object that you want to trigger a feedback effect when it collides with another object.

8) Add the MMFCollisionHelper script to the game object that you want to trigger the collision-based feedback effects when it collides with another object.

9) Drag the game object with the MMFCollisionManager script attached to it into the MMFCollisionManager field of the MMFCollisionHelper script.

10) Set the MMFCollisionListName field of the MMFCollisionHelper script to the name of the MMFCollisionLists element in the MMFCollisionManager script's mMFCollisionLists list that you want to use for this game object.

11) Repeat steps 8-10 for each game object that you want to trigger collision-based feedback effects when it collides with another object.

Now, when the game objects with the MMFCollisionHelper script attached to them collide with other objects that are in the specified layer(s), the MMFCollisionManager script will trigger the appropriate feedback effect(s).
