### PR TITLE
Create MMFCollisionHelper

### DIFF
--- a/MMFCollisionHelper
+++ b/MMFCollisionHelper
@@ -1,0 +1,26 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using static MMFCollisionManager;
+
+public class MMFCollisionHelper : MonoBehaviour
+{
+    public MMFCollisionManager MMFCollisionManager;
+    public string MMFCollisionListName;
+
+    private void OnTriggerEnter(Collider other)
+    {
+        // Find the MMFCollisionLists that contains the collided gameObject
+        MMFCollisionLists mMFCollisionList = MMFCollisionManager.mMFCollisionLists.Find(x => x.Name == MMFCollisionListName);
+
+        // Find the MMFObjects that contains the collided gameObject
+        MMFObjects feedbackObject = mMFCollisionList.feedbackObjects.Find(x => x.GameObject == other.gameObject);
+
+        // Check if the MMFCollisionLists exists and the colliding object is in the specified layer
+        if (mMFCollisionList != null && feedbackObject.LayerMask == (feedbackObject.LayerMask | (1 << other.gameObject.layer)))
+        {
+            // Call the CheckAndPlay method with the colliding object
+            MMFCollisionManager.CheckAndPlay(other.gameObject);
+        }
+    }
+}


### PR DESCRIPTION
There are several advantages to using the MMFCollisionManager and MMFCollisionHelper scripts in a Unity project:

Centralized management: The MMFCollisionManager script serves as a central location for managing all of the collision-based feedback effects in the project. This can make it easier to organize and manage these effects, especially if there are many of them.

Reusability: The MMFCollisionHelper script can be attached to any game object in the project, allowing you to reuse the same collision-based feedback effects on multiple objects.

Customization: The MMFCollisionManager script allows you to specify different feedback effects and layers for each game object, giving you the flexibility to customize the behavior of the collision-based feedback effects.

Modularity: The MMFCollisionManager and MMFCollisionHelper scripts are modular, meaning that they can be easily added or removed from a project without affecting the rest of the code. This can make it easier to add or remove collision-based feedback effects as needed.

Overall, using the MMFCollisionManager and MMFCollisionHelper scripts can help you to efficiently and effectively manage and trigger collision-based feedback effects in your Unity project.