### PR TITLE
fix: Disable OnMouseDrag event handling in non-mobile platforms

### DIFF
--- a/MasterAudio/MMFMasterAudioEvent.cs
+++ b/MasterAudio/MMFMasterAudioEvent.cs
@@ -182,9 +182,9 @@ namespace MoreMountains.Feedbacks
 #if UNITY_IPHONE || UNITY_ANDROID
     // no mouse events!
 #else
-                    if (eType == EventType.OnMouseDrag) {
+                    /*if (eType == EventType.OnMouseDrag) {
                         _mouseDragResult = soundPlayed;
-                    }
+                    }*/
 #endif
                     break;
                 case MasterAudio.EventSoundFunctionType.PlaylistControl:


### PR DESCRIPTION
The OnMouseDrag event handling code has been commented out for non-mobile platforms. This change prevents unnecessary processing of mouse drag events where they are not needed. The modification helps streamline the event logic across platforms.